### PR TITLE
fixing rn 0.25.1 deprecation warnings

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var React = require('react-native');
-var { requireNativeComponent, PropTypes, View } = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var { requireNativeComponent, PropTypes, View } = ReactNative;
 
 var NativeCalendar = requireNativeComponent('CalendarAndroid', Calendar);
 


### PR DESCRIPTION
requiring React from the `react-native` package is now deprecated, and will be [forbidden](https://github.com/facebook/react-native/releases/tag/v0.26.0-rc) in rn 0.26
